### PR TITLE
Few improvements to regex pattern and IP related information grabber

### DIFF
--- a/ip-grabber.sh
+++ b/ip-grabber.sh
@@ -247,7 +247,7 @@ printf "\e[1;92m[\e[0m*\e[1;92m] Starting ngrok server...\n"
 ./ngrok http 3333 > /dev/null 2>&1 &
 sleep 10
 
-link=$(curl -s -N http://127.0.0.1:4040/api/tunnels | grep -Po "https://[\w\-\.]+")
+link=$(curl -s -N http://127.0.0.1:4040/api/tunnels | grep -Po 'https:\/\/.+?ngrok[^",]+')
 printf "\e[1;92m[\e[0m*\e[1;92m] Send this link to the Victim:\e[0m\e[1;77m %s\e[0m\n" $link
 checkfound
 }

--- a/ip-grabber.sh
+++ b/ip-grabber.sh
@@ -82,70 +82,70 @@ rm -rf iptracker.log
 fi
 
 IFS='\n'
-iptracker=$(curl -s -L "www.ip-tracker.org/locator/ip-lookup.php?ip=$ip" --user-agent "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.31 (KHTML, like Gecko) Chrome/26.0.1410.63 Safari/537.31" > iptracker.log)
+# send a get request to an API for IP related information
+# and save the information in ./iptracker.log
+curl -s http://ip-api.com/json/$ip?fields=status,continent,query,reverse,country,regionName,city,isp,currency,as | json_pp > ./iptracker.log
+printf "\n"
+
 IFS=$'\n'
-continent=$(grep -o 'Continent.*' iptracker.log | head -n1 | cut -d ">" -f3 | cut -d "<" -f1)
-printf "\n"
-hostnameip=$(grep  -o "</td></tr><tr><th>Hostname:.*" iptracker.log | cut -d "<" -f7 | cut -d ">" -f2)
-if [[ $hostnameip != "" ]]; then
-printf "\e[1;92m[*] Hostname:\e[0m\e[1;77m %s\e[0m\n" $hostnameip
-fi
-##
+status=$(jq -r .status ./iptracker.log | tr [:upper:] [:lower:])
+if [[ $status == "success" ]]; then
+    continent=$(jq -r .continent ./iptracker.log)
+    if [[ $continent != "" ]]; then
+        printf "\e[1;92m[*] IP Continent:\e[0m\e[1;77m %s\e[0m\n" $continent
+    fi
+    ##
 
-reverse_dns=$(grep -a "</td></tr><tr><th>Hostname:.*" iptracker.log | cut -d "<" -f1)
-if [[ $reverse_dns != "" ]]; then
-printf "\e[1;92m[*] Reverse DNS:\e[0m\e[1;77m %s\e[0m\n" $reverse_dns
-fi
-##
+    hostnameip=$(jq -r .query ./iptracker.log)
+    if [[ $hostnameip != "" ]]; then
+        printf "\e[1;92m[*] Hostname:\e[0m\e[1;77m %s\e[0m\n" $hostnameip
+    fi
+    ##
 
+    reverse_dns=$(jq -r .reverse ./iptracker.log)
+    if [[ $reverse_dns != "" ]]; then
+        printf "\e[1;92m[*] Reverse DNS:\e[0m\e[1;77m %s\e[0m\n" $reverse_dns
+    fi
+    ##
 
-if [[ $continent != "" ]]; then
-printf "\e[1;92m[*] IP Continent:\e[0m\e[1;77m %s\e[0m\n" $continent
-fi
-##
+    country=$(jq -r .country ./iptracker.log)
+    if [[ $country != "" ]]; then
+        printf "\e[1;92m[*] IP Country:\e[0m\e[1;77m %s\e[0m\n" $country
+    fi
+    ##
 
-country=$(grep -o 'Country:.*' iptracker.log | cut -d ">" -f3 | cut -d "&" -f1)
-if [[ $country != "" ]]; then
-printf "\e[1;92m[*] IP Country:\e[0m\e[1;77m %s\e[0m\n" $country
-fi
-##
+    state=$(jq -r .regionName ./iptracker.log)
+    if [[ $state != "" ]]; then
+        printf "\e[1;92m[*] State:\e[0m\e[1;77m %s\e[0m\n" $state
+    fi
+    ##
 
-state=$(grep -o "tracking lessimpt.*" iptracker.log | cut -d "<" -f1 | cut -d ">" -f2)
-if [[ $state != "" ]]; then
-printf "\e[1;92m[*] State:\e[0m\e[1;77m %s\e[0m\n" $state
-fi
-##
-city=$(grep -o "City Location:.*" iptracker.log | cut -d "<" -f3 | cut -d ">" -f2)
+    city=$(jq -r .city ./iptracker.log)
+    if [[ $city != "" ]]; then
+        printf "\e[1;92m[*] City Location:\e[0m\e[1;77m %s\e[0m\n" $city
+    fi
+    ##
 
-if [[ $city != "" ]]; then
-printf "\e[1;92m[*] City Location:\e[0m\e[1;77m %s\e[0m\n" $city
-fi
-##
+    isp=$(jq -r .isp ./iptracker.log)
+    if [[ $isp != "" ]]; then
+        printf "\e[1;92m[*] ISP:\e[0m\e[1;77m %s\e[0m\n" $isp
+    fi
+    ##
 
-isp=$(grep -o "ISP:.*" iptracker.log | cut -d "<" -f3 | cut -d ">" -f2)
-if [[ $isp != "" ]]; then
-printf "\e[1;92m[*] ISP:\e[0m\e[1;77m %s\e[0m\n" $isp
-fi
-##
+    as_number=$(jq -r .as ./iptracker.log)
+    if [[ $as_number != "" ]]; then
+        printf "\e[1;92m[*] AS Number:\e[0m\e[1;77m %s\e[0m\n" $as_number
+    fi
+    ##
 
-as_number=$(grep -o "AS Number:.*" iptracker.log | cut -d "<" -f3 | cut -d ">" -f2)
-if [[ $as_number != "" ]]; then
-printf "\e[1;92m[*] AS Number:\e[0m\e[1;77m %s\e[0m\n" $as_number
+    ip_currency=$(jq -r .currency ./iptracker.log)
+    if [[ $ip_currency != "" ]]; then
+        printf "\e[1;92m[*] IP Currency:\e[0m\e[1;77m %s\e[0m\n" $ip_currency
+    fi
+    ##
+    
+    printf "\n"
 fi
-##
-
-ip_speed=$(grep -o "IP Address Speed:.*" iptracker.log | cut -d "<" -f3 | cut -d ">" -f2)
-if [[ $ip_speed != "" ]]; then
-printf "\e[1;92m[*] IP Address Speed:\e[0m\e[1;77m %s\e[0m\n" $ip_speed
-fi
-##
-ip_currency=$(grep -o "IP Currency:.*" iptracker.log | cut -d "<" -f3 | cut -d ">" -f2)
-
-if [[ $ip_currency != "" ]]; then
-printf "\e[1;92m[*] IP Currency:\e[0m\e[1;77m %s\e[0m\n" $ip_currency
-fi
-##
-printf "\n"
 rm -rf iptracker.log
 printf "\e[1;93m[\e[0m\e[1;77m*\e[0m\e[1;93m] Waiting till the next victim to open the link send to another person, Press Ctrl + C to exit...\e[0m\n"
 
@@ -247,7 +247,7 @@ printf "\e[1;92m[\e[0m*\e[1;92m] Starting ngrok server...\n"
 ./ngrok http 3333 > /dev/null 2>&1 &
 sleep 10
 
-link=$(curl -s -N http://127.0.0.1:4040/api/tunnels | grep -o "https://[0-9a-z]*\.ngrok.io")
+link=$(curl -s -N http://127.0.0.1:4040/api/tunnels | grep -Po "https://[\w\-\.]+")
 printf "\e[1;92m[\e[0m*\e[1;92m] Send this link to the Victim:\e[0m\e[1;77m %s\e[0m\n" $link
 checkfound
 }


### PR DESCRIPTION
Changes are listed below: 

1. In correct regex pattern is used along with the curl request to get the IP address to send to the victim.
    
    currently in the master code, this regex pattern is being used `https://[0-9a-z]*\.ngrok.io` but in the newer versions of ngrok, if you check out the IP Address you'll get this type of top & second level domain name "ngrok.free.app", as this thing is completely in the hand of ngrok developers to use whatever top and second level domain, I think it's better to use a different regex pattern that doesn't suppose to end with a specific word, in my case I've used this one : `https:\/\/.+?ngrok[^",]+`. 
    
    This regex pattern starts with HTTPS, then first matches till ngrok, then matches everything including the "ngrok" itself till comma or double quote. We get JSON format data from the local server of ngrok, so I think this regex pattern could be a good fit here. JSON data example: 
    ```
    {"tunnels":[{"name":"command_line","uri":"/api/tunnels/command_line","public_url":"https://0fd1-2409-40xx-xxx-xxxx-xxxx-xxxx-xxxx-xxxx.ngrok-free.app","proto":"https"........
    ```

2. Using an API to get IP related information instead of the URL specified in the current code snippet
    
    In the code snippet, currently if you see, this URL (`www.ip-tracker.org/locator/ip-lookup.php?ip=$ip`) is used to get the relevant information about the IP address, like city, country, state, isp etc. However, when I visited to this URL using my IP Address, it showed me a prompt to first verify myself and due to this, I was not getting IP related information printed on my terminal when I sent the link to the victim, only the IP Address of him and user agent were printed. 
    
    ![image](https://github.com/krishpranav/IP-Grabber/assets/33115688/ec72b0b8-9a93-42d5-8eee-4ce5f65468ad)
    
    This can be frustrating at times, instead of this URL we can make a use of an API which is free of use for non-commerical purpose, this API doesn't require any key or authorization/authentication thing in order to query. It's simple and can serve great to the users, you can find more about it on [ip-api.com](https://ip-api.com/).
    Also on line 85, there's an unused variable assignment i.e., 
    ```sh
    iptracker=$(curl -s -L "www.ip-tracker.org/locator/ip-lookup.php?ip=$ip" --user-agent "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.31 (KHTML, like Gecko) Chrome/26.0.1410.63 Safari/537.31" > iptracker.log)
    ```
    I don't see any reason of assinging the value to this variable when you are writing everything into a file. This variable also isn't used anywhere in the code, later I have also changed the few conditional statements in order to make it more readable and, since we are getting result in the JSON format from the API, then it's better to use `jq` command line tool to parse the JSON data and get particular values of keys. 
    
    Final Result: 
     
    ![image](https://github.com/krishpranav/IP-Grabber/assets/33115688/188fee64-6441-4a19-a56c-12b4a2331102)

